### PR TITLE
Nav - Fix page layout demos

### DIFF
--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -84,19 +84,19 @@ class PageLayoutDefaultNav extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
-          <NavItem to="#nav-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem to="#nav-link1" preventDefault itemId={0} isActive={activeItem === 0}>
             System Panel
           </NavItem>
-          <NavItem to="#nav-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem to="#nav-link2" preventDefault itemId={1} isActive={activeItem === 1}>
             Policy
           </NavItem>
-          <NavItem to="#nav-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem to="#nav-link3" preventDefault itemId={2} isActive={activeItem === 2}>
             Authentication
           </NavItem>
-          <NavItem to="#nav-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem to="#nav-link4" preventDefault itemId={3} isActive={activeItem === 3}>
             Network Services
           </NavItem>
-          <NavItem to="#nav-link5" itemId={4} isActive={activeItem === 4}>
+          <NavItem to="#nav-link5" preventDefault itemId={4} isActive={activeItem === 4}>
             Server
           </NavItem>
         </NavList>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -88,38 +88,98 @@ class PageLayoutExpandableNav extends React.Component {
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
           <NavExpandable title="System Panel" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
-            <NavItem to="#expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+            <NavItem
+              to="#expandable-1"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-1"
+              isActive={activeItem === 'grp-1_itm-1'}
+            >
               Overview
             </NavItem>
-            <NavItem to="#expandable-2" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+            <NavItem
+              to="#expandable-2"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-2"
+              isActive={activeItem === 'grp-1_itm-2'}
+            >
               Resource Usage
             </NavItem>
-            <NavItem to="#expandable-3" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+            <NavItem
+              to="#expandable-3"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-3"
+              isActive={activeItem === 'grp-1_itm-3'}
+            >
               Hypervisors
             </NavItem>
-            <NavItem to="#expandable-4" groupId="grp-1" itemId="grp-1_itm-4" isActive={activeItem === 'grp-1_itm-4'}>
+            <NavItem
+              to="#expandable-4"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-4"
+              isActive={activeItem === 'grp-1_itm-4'}
+            >
               Instances
             </NavItem>
-            <NavItem to="#expandable-5" groupId="grp-1" itemId="grp-1_itm-5" isActive={activeItem === 'grp-1_itm-5'}>
+            <NavItem
+              to="#expandable-5"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-5"
+              isActive={activeItem === 'grp-1_itm-5'}
+            >
               Volumes
             </NavItem>
-            <NavItem to="#expandable-6" groupId="grp-1" itemId="grp-1_itm-6" isActive={activeItem === 'grp-1_itm-6'}>
+            <NavItem
+              to="#expandable-6"
+              preventDefault
+              groupId="grp-1"
+              itemId="grp-1_itm-6"
+              isActive={activeItem === 'grp-1_itm-6'}
+            >
               Network
             </NavItem>
           </NavExpandable>
           <NavExpandable title="Policy" groupId="grp-2" isActive={activeGroup === 'grp-2'}>
-            <NavItem to="#expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+            <NavItem
+              to="#expandable-4"
+              preventDefault
+              groupId="grp-2"
+              itemId="grp-2_itm-1"
+              isActive={activeItem === 'grp-2_itm-1'}
+            >
               Subnav Link 1
             </NavItem>
-            <NavItem to="#expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+            <NavItem
+              to="#expandable-5"
+              preventDefault
+              groupId="grp-2"
+              itemId="grp-2_itm-2"
+              isActive={activeItem === 'grp-2_itm-2'}
+            >
               Subnav Link 2
             </NavItem>
           </NavExpandable>
           <NavExpandable title="Authentication" groupId="grp-3" isActive={activeGroup === 'grp-3'}>
-            <NavItem to="#expandable-7" groupId="grp-3" itemId="grp-3_itm-1" isActive={activeItem === 'grp-3_itm-1'}>
+            <NavItem
+              to="#expandable-7"
+              preventDefault
+              groupId="grp-3"
+              itemId="grp-3_itm-1"
+              isActive={activeItem === 'grp-3_itm-1'}
+            >
               Subnav Link 1
             </NavItem>
-            <NavItem to="#expandable-8" groupId="grp-3" itemId="grp-3_itm-2" isActive={activeItem === 'grp-3_itm-2'}>
+            <NavItem
+              to="#expandable-8"
+              preventDefault
+              groupId="grp-3"
+              itemId="grp-3_itm-2"
+              isActive={activeItem === 'grp-3_itm-2'}
+            >
               Subnav Link 2
             </NavItem>
           </NavExpandable>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -78,33 +78,33 @@ class PageLayoutGroupsNav extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavGroup title="System Panel">
-          <NavItem to="#grouped-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+          <NavItem to="#grouped-1" preventDefault itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
             Overview
           </NavItem>
-          <NavItem to="#grouped-2" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+          <NavItem to="#grouped-2" preventDefault itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
             Resource Usage
           </NavItem>
-          <NavItem to="#grouped-3" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+          <NavItem to="#grouped-3" preventDefault itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
             Hypervisors
           </NavItem>
-          <NavItem to="#grouped-4" itemId="grp-1_itm-4" isActive={activeItem === 'grp-1_itm-4'}>
+          <NavItem to="#grouped-4" preventDefault itemId="grp-1_itm-4" isActive={activeItem === 'grp-1_itm-4'}>
             Instances
           </NavItem>
-          <NavItem to="#grouped-5" itemId="grp-1_itm-5" isActive={activeItem === 'grp-1_itm-5'}>
+          <NavItem to="#grouped-5" preventDefault itemId="grp-1_itm-5" isActive={activeItem === 'grp-1_itm-5'}>
             Volumes
           </NavItem>
-          <NavItem to="#grouped-6" itemId="grp-1_itm-6" isActive={activeItem === 'grp-1_itm-6'}>
+          <NavItem to="#grouped-6" preventDefault itemId="grp-1_itm-6" isActive={activeItem === 'grp-1_itm-6'}>
             Network
           </NavItem>
         </NavGroup>
         <NavGroup title="Policy">
-          <NavItem to="#grouped-7" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+          <NavItem to="#grouped-7" preventDefault itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
             Hosts
           </NavItem>
-          <NavItem to="#grouped-8" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+          <NavItem to="#grouped-8" preventDefault itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
             Virtual Machines
           </NavItem>
-          <NavItem to="#grouped-9" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
+          <NavItem to="#grouped-9" preventDefault itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
             Storage
           </NavItem>
         </NavGroup>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -84,19 +84,19 @@ class PageLayoutHorizontalNav extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList variant={NavVariants.horizontal}>
-          <NavItem to="#nav-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem to="#nav-link1" preventDefault itemId={0} isActive={activeItem === 0}>
             System Panel
           </NavItem>
-          <NavItem to="#nav-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem to="#nav-link2" preventDefault itemId={1} isActive={activeItem === 1}>
             Policy
           </NavItem>
-          <NavItem to="#nav-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem to="#nav-link3" preventDefault itemId={2} isActive={activeItem === 2}>
             Authentication
           </NavItem>
-          <NavItem to="#nav-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem to="#nav-link4" preventDefault itemId={3} isActive={activeItem === 3}>
             Network Services
           </NavItem>
-          <NavItem to="#nav-link5" itemId={4} isActive={activeItem === 4}>
+          <NavItem to="#nav-link5" preventDefault itemId={4} isActive={activeItem === 4}>
             Server
           </NavItem>
         </NavList>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
@@ -45,7 +45,7 @@ class PageLayoutManualNav extends React.Component {
       activeItem: 0,
       isMobileView: false,
       isNavOpenDesktop: true,
-      isNavOpenMobile: false
+      isNavOpenMobile: true
     };
   }
 
@@ -110,19 +110,19 @@ class PageLayoutManualNav extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
-          <NavItem to="#nav-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem to="#nav-link1" preventDefault itemId={0} isActive={activeItem === 0}>
             System Panel
           </NavItem>
-          <NavItem to="#nav-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem to="#nav-link2" preventDefault itemId={1} isActive={activeItem === 1}>
             Policy
           </NavItem>
-          <NavItem to="#nav-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem to="#nav-link3" preventDefault itemId={2} isActive={activeItem === 2}>
             Authentication
           </NavItem>
-          <NavItem to="#nav-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem to="#nav-link4" preventDefault itemId={3} isActive={activeItem === 3}>
             Network Services
           </NavItem>
-          <NavItem to="#nav-link5" itemId={4} isActive={activeItem === 4}>
+          <NavItem to="#nav-link5" preventDefault itemId={4} isActive={activeItem === 4}>
             Server
           </NavItem>
         </NavList>
@@ -196,6 +196,7 @@ class PageLayoutManualNav extends React.Component {
         isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop}
       />
     );
+    debugger;
     const Sidebar = <PageSidebar nav={PageNav} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop} />;
     const PageSkipToContent = (
       <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
@@ -45,7 +45,7 @@ class PageLayoutManualNav extends React.Component {
       activeItem: 0,
       isMobileView: false,
       isNavOpenDesktop: true,
-      isNavOpenMobile: true
+      isNavOpenMobile: false
     };
   }
 
@@ -196,7 +196,6 @@ class PageLayoutManualNav extends React.Component {
         isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop}
       />
     );
-    debugger;
     const Sidebar = <PageSidebar nav={PageNav} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop} />;
     const PageSkipToContent = (
       <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -83,19 +83,19 @@ class PageLayoutSimpleNav extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList variant={NavVariants.simple}>
-          <NavItem to="#nav-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem to="#nav-link1" preventDefault itemId={0} isActive={activeItem === 0}>
             System Panel
           </NavItem>
-          <NavItem to="#nav-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem to="#nav-link2" preventDefault itemId={1} isActive={activeItem === 1}>
             Policy
           </NavItem>
-          <NavItem to="#nav-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem to="#nav-link3" preventDefault itemId={2} isActive={activeItem === 2}>
             Authentication
           </NavItem>
-          <NavItem to="#nav-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem to="#nav-link4" preventDefault itemId={3} isActive={activeItem === 3}>
             Network Services
           </NavItem>
-          <NavItem to="#nav-link5" itemId={4} isActive={activeItem === 4}>
+          <NavItem to="#nav-link5" preventDefault itemId={4} isActive={activeItem === 4}>
             Server
           </NavItem>
         </NavList>


### PR DESCRIPTION
Add preventDefault to NavItem components so that there is no actual routing to the respective `to` prop attempted. This is needed, otherwise on click it routes to the new URL and the NavItem component gets rendered again (and therefore the active item is not remembered). 